### PR TITLE
SSH鍵の作成を事前に行うように

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,8 @@ MAKEFLAGS+=--no-print-directory
 # Constants
 HOSTNAME:=$(CONTEST)-$(STACK)-$(SERVER_ID)
 SSH_DIR:=$(HOME)/.ssh
-SSH_KEY_PATH:=$(SSH_DIR)/id_ed25519
-SSH_KEY_COMMENT:=$(STACK)@$(CONTEST)-$(SERVER_ID)
 GIT_DEFAULT_BRANCH:=main
+SSH_KEY_PATH:=$(SSH_DIR)/id_ed25519
 GIT_USER:=$(STACK)@$(CONTEST)-$(SERVER_ID)
 WORKING_DIR:=$(HOME)/$(WORKING_DIR_RELATIVE)
 
@@ -73,17 +72,9 @@ setup-git:
 setup-ssh:
 	@echo "###############################################"
 	@echo "Setting up SSH..."
-	@mkdir -p $(SSH_DIR)
-	@ssh-keygen -t ed25519 -C $(SSH_KEY_COMMENT) -f $(SSH_KEY_PATH) -N '' > /dev/null
+	@ssh-keygen -y -f $(SSH_KEY_PATH) > $(SSH_KEY_PATH).pub
 	@cp ./ssh-config $(SSH_DIR)/config
-	@echo "Add the following public key to GitHub:"	
-	@cat $(SSH_KEY_PATH).pub
-	@$(MAKE) wait-for-enter
 	@echo "SSH setup complete."
-
-wait-for-enter:
-	@echo "Press enter to continue..."
-	@read _
 
 check-github-ssh:
 	@echo "###############################################"
@@ -112,4 +103,4 @@ setup-working-dir:
 	fi
 	@echo "Working directory setup complete. Navigate to $(WORKING_DIR) to start working."
 
-.PHONY: default setup check-env set-hostname setup-ssh setup-git wait-for-enter setup-working-dir check-github-ssh
+.PHONY: default setup check-env set-hostname setup-ssh setup-git check-github-ssh setup-working-dir 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 ISUCONの作業環境を構築するためのレポジトリです。
 
+## 事前準備
+
+`$HOME/.ssh/`にSSH秘密鍵`id_ed25519`を配置
+
+ローカル端末からの送信例：
+
+```sh
+# 鍵の作成
+ssh-keygen -t ed25519 -C "isucon-server" -f ./id_ed25519 -N ""
+
+# 鍵の送信
+scp ./id_ed25519 isucon9q-prod-s1:/home/isucon/.ssh/id_ed25519
+```
+
 ## 使い方
 
 レポジトリのインストール

--- a/README.md
+++ b/README.md
@@ -4,15 +4,19 @@ ISUCONの作業環境を構築するためのレポジトリです。
 
 ## 事前準備
 
-`$HOME/.ssh/`にSSH秘密鍵`id_ed25519`を配置
+- `$HOME/.ssh/`にSSH秘密鍵`id_ed25519`を配置する
+- 公開鍵`id_ed25519.pub`をisuconのリポジトリのdeployキーに登録する
 
 ローカル端末からの送信例：
 
 ```sh
-# 鍵の作成
+# 鍵ペアの作成
 ssh-keygen -t ed25519 -C "isucon-server" -f ./id_ed25519 -N ""
 
-# 鍵の送信
+# 公開鍵をクリップボードにコピー （これをGitHubに登録）
+cat id_ed25519.pub | pbcopy
+
+# 秘密鍵をサーバーに送信
 scp ./id_ed25519 isucon9q-prod-s1:/home/isucon/.ssh/id_ed25519
 ```
 


### PR DESCRIPTION
- MakefileでSSH鍵の作成のロジックを削除
- ローカルでのSSH鍵作成方法、送信方法をREADMEに追加